### PR TITLE
Refactor: migrate all providers to BaseProvider ABC

### DIFF
--- a/eagleosint/plugin.py
+++ b/eagleosint/plugin.py
@@ -2,7 +2,10 @@
 BaseProvider ABC and ProviderCategory Enum
 
 Every provider plugin must subclass BaseProvider and implement execute().
-Existing CLI are not yet migrated -- this is the target interface.
+Migrated: GitHubProvider, BitlyProvider, PhoneInfoProvider,
+          IPLocationProvider, DomainInfoProvider, MailFinderProvider,
+          UserReconProvider, GoDorkerProvider.
+Pending:  Facebook (deprecated API — isolate/remove), TempMail (polling pattern).
 """
 
 from __future__ import annotations

--- a/eagleosint/providers/bitly.py
+++ b/eagleosint/providers/bitly.py
@@ -1,5 +1,8 @@
 ﻿"""Bitly URL shortener bypass."""
+from __future__ import annotations
+import logging
 import urllib.parse
+from typing import ClassVar
 from getpass import getpass
 
 import requests
@@ -10,41 +13,72 @@ from eagleosint.display import (
     BG_BLUE,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import session as _session
 from eagleosint.models import URLExpansion
 
+logger = logging.getLogger(__name__)
+
+class BitlyProvider(BaseProvider):
+    name = "bitly"
+    version = "1.0.0"
+    description = "Resolve shortened Bitly URLs to their original destination"
+    category = ProviderCategory.UTILITY
+    required_keys: ClassVar[list[str]] = []
+
+    def validate_query(self, query: str) -> str | None:
+        base = super().validate_query(query)
+        if base:
+            return base
+        parsed = urllib.parse.urlparse(query)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            return "Invalid URL. Must start with http:// or https://"
+        return None
+
+    def execute(self, query: str) -> list[URLExpansion]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("Invalid query: %s", error)
+            return []
+
+        try:
+            response = _session.get(query, allow_redirects=False, timeout=10)
+            soup = BeautifulSoup(response.text, "lxml")
+            original_url = str(soup.find_all("a", href=True)[0]["href"])
+        except requests.exceptions.RequestException as e:
+            logger.error("Bitly fetch error: %s", e)
+            return []
+        except (IndexError, KeyError) as e:
+            logger.error("Bitly parse error: %s", e)
+            return []
+
+        return [URLExpansion(
+            query=query,
+            short_url=query,
+            original_url=original_url,
+        )]
 
 def bypass_bitly() -> URLExpansion | None:
-    """Bypasses Bitly URL shorteners."""
+    """Interactive CLI wrapper — prompts for URL, prints result."""
     print(WHITE + LINES_SEPARATOR)
-    bitly_url_input = input(
+    bitly_url = input(
         f"{SPACE_PREFIX}{WHITE}{BLUE}>{WHITE} Bitly URL: {BLUE}"
     ).strip()
-    parsed = urllib.parse.urlparse(bitly_url_input)
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
-        print(f"{RED}Invalid URL. Must start with http:// or https://{WHITE}")
-        return
-    try:
-        bitly_code_response = _session.get(
-            bitly_url_input, allow_redirects=False, timeout=10
-        )
-        soup_parser = BeautifulSoup(bitly_code_response.text, "lxml")
-        original_link_found = soup_parser.find_all("a", href=True)[0]["href"]
-        result = URLExpansion(
-            query=bitly_url_input,
-            short_url=bitly_url_input,
-            original_url=original_link_found,
-        )
-        print(
-            f"{SPACE_PREFIX}{BG_BLUE} DONE {WHITE} Original URL: "
-            f"\u001b[38;5;32m{original_link_found}"
-        )
-    except requests.exceptions.RequestException as e:
-        print(f"{RED}Error fetching Bitly URL: {e}{WHITE}")
+
+    provider = BitlyProvider()
+    results = provider.execute(bitly_url)
+
+    if not results:
+        print(f"{RED}No results for '{bitly_url}'.{WHITE}")
+        print(WHITE + LINES_SEPARATOR)
+        getpass(SPACE_PREFIX + "press enter for back to previous menu ")
         return None
-    except (IndexError, KeyError) as e:
-        print(f"{RED}Error parsing Bitly response: {e}{WHITE}")
-        return None
+
+    result = results[0]
+    print(
+        f"{SPACE_PREFIX}{BG_BLUE} DONE {WHITE} Original URL: "
+        f"\u001b[38;5;32m{result.original_url}"
+    )
     print(WHITE + LINES_SEPARATOR)
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
     return result

--- a/eagleosint/providers/github.py
+++ b/eagleosint/providers/github.py
@@ -2,6 +2,8 @@
 import json
 import re
 from getpass import getpass
+from typing import ClassVar
+import logging
 
 import requests
 from tabulate import tabulate
@@ -10,54 +12,85 @@ from eagleosint.display import (
     RED, BLUE, WHITE,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import session as _session
 from eagleosint.models import GitHubProfile
 
+logger = logging.getLogger(__name__)
+
 GITHUB_API_URL = "https://api.github.com/users/{}"
 
+class GithubProvider(BaseProvider):
+    name = "github"
+    version = "1.0.0"
+    description = "GitHub user profile lookup via public REST API"
+    category = ProviderCategory.SOCIAL
+    required_keys: ClassVar[list[str]] = []
+
+    def execute(self, query: str) -> list[GitHubProfile]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("Invalid query: %s", error)
+            return []
+
+        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}$", query):
+            logger.warning("Invalid GitHub username: %s", query)
+            return []
+
+        try:
+            response = _session.get(GITHUB_API_URL.format(query), timeout=10)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            logger.error("GitHub API error: %s", e)
+            return []
+        except json.JSONDecodeError:
+            logger.error("Invalid JSON response from GitHub API")
+            return []
+
+        profile = GitHubProfile(
+            query=query,
+            username=data.get("login", query),
+            name=data.get("name"),
+            email=data.get("email"),
+            bio=data.get("bio"),
+            location=data.get("location"),
+            company=data.get("company"),
+            blog=data.get("blog"),
+            public_repos=data.get("public_repos"),
+            followers=data.get("followers"),
+            following=data.get("following"),
+            created_at=data.get("created_at"),
+            avatar_url=data.get("avatar_url"),
+            html_url=data.get("html_url"),
+            raw=data,
+        )
+        return [profile]
 
 def github_lookup() -> GitHubProfile | None:
-    """Retrieves and displays information about a GitHub user."""
+    """Interactive CLI wrapper — prompts for username, prints table."""
     print(WHITE + LINES_SEPARATOR)
     github_user = input(
         f"{SPACE_PREFIX}{WHITE}{BLUE}>{WHITE} Github username: {BLUE}"
     ).strip()
-    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}$", github_user):
-        print(f"{RED}Invalid Github username.{WHITE}")
-        return
     print(WHITE)
-    try:
-        req = _session.get(GITHUB_API_URL.format(github_user), timeout=10)
-        res_data = req.json()
-        table_data = [[str(k), str(v)] for k, v in res_data.items()]
-        for line_item in tabulate(
-            table_data, headers=["info", "content"], tablefmt="fancy_grid"
-        ).splitlines():
-            print(" " * int(len(SPACE_PREFIX) / 2) + line_item)
 
-        profile = GitHubProfile(
-            query=github_user,
-            username=res_data.get("login", github_user),
-            name=res_data.get("name"),
-            email=res_data.get("email"),
-            bio=res_data.get("bio"),
-            location=res_data.get("location"),
-            company=res_data.get("company"),
-            blog=res_data.get("blog"),
-            public_repos=res_data.get("public_repos"),
-            followers=res_data.get("followers"),
-            following=res_data.get("following"),
-            created_at=res_data.get("created_at"),
-            avatar_url=res_data.get("avatar_url"),
-            html_url=res_data.get("html_url"),
-            raw=res_data,
-        )
-    except requests.exceptions.RequestException as e:
-        print(f"{RED}Error fetching GitHub user information: {e}{WHITE}")
+    provider = GithubProvider()
+    results = provider.execute(github_user)
+
+    if not results:
+        print(f"{RED}No results for '{github_user}'.{WHITE}")
+        print(WHITE + LINES_SEPARATOR)
+        getpass(SPACE_PREFIX + "press enter for back to previous menu ")
         return None
-    except json.JSONDecodeError:
-        print(f"{RED}Error decoding JSON response from GitHub.{WHITE}")
-        return None
+
+    profile = results[0]
+
+    table_data = [[str(key), str(value)] for key, value in profile.raw.items()]
+    for line_item in tabulate(
+        table_data, headers=["info", "content"], tablefmt="fancy_grid"
+    ).splitlines():
+        print(" " * int(len(SPACE_PREFIX) / 2) + line_item)
 
     print(WHITE + LINES_SEPARATOR)
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")

--- a/eagleosint/providers/godorker.py
+++ b/eagleosint/providers/godorker.py
@@ -1,6 +1,9 @@
 ﻿"""Google dorking search and result scraper."""
+from __future__ import annotations
+import logging
 import textwrap
 from getpass import getpass
+from typing import Callable, ClassVar
 
 import requests
 from googlesearch import search  # type: ignore
@@ -11,57 +14,101 @@ from eagleosint.display import (
     BG_BLUE,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.models import DorkResult
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import HEADERS, session as _session
+
+logger = logging.getLogger(__name__)
 
 RESULTS_GODORKER_TXT = "result_godorker.txt"
 
+class GoDorkerProvider(BaseProvider):
+    name = "godorker"
+    version = "1.0.0"
+    description = "Google dorking search with result scraping"
+    category = ProviderCategory.UTILITY
 
-def godorker():
-    """Performs Google dorking and saves the results to a file."""
+    def execute(
+            self,
+            query: str,
+            num_results: int = 30,
+            on_result: Callable | None = None,
+    ) -> list[DorkResult]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
+
+        urls: list[str] = []
+        try:
+            for url in search(query, num_results=num_results, timeout=5):
+                urls.append(url)
+        except Exception as e:
+            logger.error("Google search error: %s", e)
+
+        results: list[DorkResult] = []
+        for url in urls:
+            title = self._fetch_title(url)
+            result = DorkResult(query=query, url=url, title=title)
+            results.append(result)
+            if on_result:
+                on_result(result)
+
+        return results
+
+    def _fetch_title(self, url: str) -> str | None:
+        """Fetch the page title for a URL."""
+        try:
+            resp = _session.get(url, headers=HEADERS, timeout=10)
+            resp.raise_for_status()
+            doc = fromstring(resp.content)
+            return doc.findtext(".//title")
+        except (requests.exceptions.RequestException, TypeError):
+            logger.debug("could not fetch title for %s", url)
+            return None
+
+
+# ------------------------------------------------------------------
+# Interactive CLI wrapper
+# ------------------------------------------------------------------
+
+def godorker() -> list[DorkResult]:
+    """Interactive CLI wrapper — prompts for dork query, prints results."""
     dork_query = input(
         f"{SPACE_PREFIX}{BLUE}>{WHITE} enter dork (inurl/intext/etc):{BLUE} "
     ).lower()
     if not dork_query:
-        return
-    print(WHITE + LINES_SEPARATOR)
-    urls_found = []
-    try:
-        for result_url in search(dork_query, num_results=30, timeout=5):
-            urls_found.append(result_url)
-    except Exception as e_search:
-        print(f"{RED}Error during Google search: {e_search}{WHITE}")
+        return []
 
-    with open(RESULTS_GODORKER_TXT, "w", encoding="utf-8") as dork_file:
-        dork_file.write(f"# Dork: {dork_query}\n\n")
-        for result_url in urls_found:
-            try:
-                req = _session.get(result_url, headers=HEADERS, timeout=10)
-                req.raise_for_status()
-                res_content = fromstring(req.content)
-                title_text = res_content.findtext(".//title")
-                if title_text:
-                    wrapper = textwrap.TextWrapper(width=47)
-                    dedented_text = textwrap.dedent(text=title_text)
-                    original_text = wrapper.fill(text=dedented_text)
-                    shortened_text = textwrap.shorten(text=original_text, width=47)
-                    formatted_title = wrapper.fill(text=shortened_text)
-                    dork_file.write(f"{result_url}\n")
-                    print(
-                        f"{SPACE_PREFIX}{BG_BLUE} FOUND {WHITE} {formatted_title}\n"
-                        f"{SPACE_PREFIX}{DARK_GRAY}{result_url}{WHITE}"
-                    )
-            except requests.exceptions.HTTPError as http_err_dork:
-                print(f"{RED}HTTP error accessing {result_url}: {http_err_dork}{WHITE}")
-            except requests.exceptions.RequestException as req_err_dork:
-                print(f"{RED}Request error accessing {result_url}: {req_err_dork}{WHITE}")
-            except TypeError:
-                print(f"{YELLOW}Could not parse title for {result_url}{WHITE}")
-            except KeyboardInterrupt:
-                print(f"{RED}Dorking aborted by user.{WHITE}")
-                break
+    print(WHITE + LINES_SEPARATOR)
+
+    output_fh = open(RESULTS_GODORKER_TXT, "w", encoding="utf-8")
+    output_fh.write(f"# Dork: {dork_query}\n\n")
+
+    def _on_result(result: DorkResult) -> None:
+        if result.title:
+            wrapper = textwrap.TextWrapper(width=47)
+            shortened = textwrap.shorten(text=result.title, width=47)
+            formatted = wrapper.fill(text=shortened)
+            print(
+                f"{SPACE_PREFIX}{BG_BLUE} FOUND {WHITE} {formatted}\n"
+                f"{SPACE_PREFIX}{DARK_GRAY}{result.url}{WHITE}"
+            )
+        output_fh.write(f"{result.url}\n")
+
+    try:
+        provider = GoDorkerProvider()
+        results = provider.execute(dork_query, on_result=_on_result)
+    except KeyboardInterrupt:
+        print(f"{RED}Dorking aborted by user.{WHITE}")
+        results = []
+    finally:
+        output_fh.close()
+
     print(WHITE + LINES_SEPARATOR)
     print(
-        f"{SPACE_PREFIX}{BLUE}>{WHITE} {str(len(urls_found))} retrieved as: "
+        f"{SPACE_PREFIX}{BLUE}>{WHITE} {len(results)} retrieved as: "
         f"{YELLOW}{RESULTS_GODORKER_TXT}"
     )
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+    return results

--- a/eagleosint/providers/mailfinder.py
+++ b/eagleosint/providers/mailfinder.py
@@ -8,6 +8,7 @@ from getpass import getpass
 from concurrent.futures import ThreadPoolExecutor
 from random import seed
 from time import sleep
+from typing import Callable
 
 import requests
 
@@ -100,7 +101,7 @@ class MailFinderProvider(BaseProvider):
             api_key: str | None = None,
             max_workers: int = 20,
             delay: float | None = None,
-            on_result: callable | None = None,
+            on_result: Callable | None = None,
     ) -> list[EmailResult]:
         error = self.validate_query(query)
         if error:

--- a/eagleosint/providers/mailfinder.py
+++ b/eagleosint/providers/mailfinder.py
@@ -1,5 +1,8 @@
 ﻿"""Email address finder via permutation + real-email validation."""
+from __future__ import annotations
+
 import json
+import logging
 import threading
 from getpass import getpass
 from concurrent.futures import ThreadPoolExecutor
@@ -8,158 +11,192 @@ from time import sleep
 
 import requests
 
-from eagleosint.config import settings, logger, save_config
+from eagleosint.config import settings, save_config
 from eagleosint.display import (
     RED, GREEN, YELLOW, BLUE, WHITE,
     BG_RED, BG_GREEN, BG_YELLOW,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import session as _session
-from eagleosint.models import EmailStatus
+from eagleosint.models import EmailStatus, EmailResult
+
+logger = logging.getLogger(__name__)
 
 PINGUTIL_DEMO_URL = "https://pingutil.com/v1/demo/lookup"
 PINGUTIL_AUTH_URL = "https://pingutil.com/v1/lookup"
 
-class _State:
-    __slots__ = ("num", "lock")
-    def __init__(self):
-        self.num = 0
-        self.lock = threading.Lock()
+EMAIL_PROVIDERS = [
+    "gmail.com", "yahoo.com", "hotmail.com", "aol.com", "msn.com",
+    "comcast.net", "live.com", "rediffmail.com", "ymail.com",
+    "outlook.com", "cox.net", "googlemail.com", "rocketmail.com",
+    "att.net", "facebook.com", "bellsouth.net", "charter.net", "sky.com",
+    "earthlink.net", "optonline.net", "qq.com", "me.com", "gmx.net",
+    "mail.com", "ntlworld.com", "frontiernet.net", "windstream.net",
+    "mac.com", "centurytel.net", "aim.com",
+]
 
+def _generate_variations(full_name: str) -> list[str]:
+    """Generate username variations from a full name."""
+    name = full_name.lower().strip()
+    joined = name.replace(" ", "")
+    variations = [
+        joined, joined + "123",
+        joined + "1234", joined.replace("i", "1"),
+        joined.replace("a", "4"), joined.replace("e", "3"),
+        joined.replace("i", "1").replace("a", "4").replace("e", "3"),
+        joined.replace("i", "1").replace("a", "4"),
+        joined.replace("i", "1").replace("e", "3"),
+        joined.replace("a", "4").replace("e", "3"),
+    ]
+    for part in name.split(" "):
+        variations.extend([part, part + "123", part + "1234"])
+    return variations
 
-def check_email(email, api_key, total, ok_list, output_file, state):
-    url = PINGUTIL_AUTH_URL if api_key else PINGUTIL_DEMO_URL
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+class MailFinderProvider(BaseProvider):
+    name = "mailfinder"
+    version = "1.0.0"
+    description = "Find email addresses by name permutation + Pingutil validation"
+    category = ProviderCategory.EMAIL
 
-    try:
-        response = _session.post(url, json={"input": email}, headers=headers, timeout=10)
-        if response.status_code != 200:
-            with state.lock:
-                state.num += 1
-                current_count = state.num
-            print(
-                f"{SPACE_PREFIX}{BG_RED}{WHITE}  ERROR  {WHITE}{BLUE} "
-                f"{current_count}/{total}{WHITE} Status: {RED}HTTP "
-                f"{response.status_code} for {email}{WHITE}"
-            )
-            return
+    def _check_single(self, email: str, api_key: str | None) -> EmailResult:
+        """Validate a single email address against Pingutil API."""
+        url = PINGUTIL_AUTH_URL if api_key else PINGUTIL_DEMO_URL
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
         try:
-            category = response.json().get("category", "unknown")
-        except json.JSONDecodeError:
-            with state.lock:
-                state.num += 1
-                current_count = state.num
-            print(
-                f"{SPACE_PREFIX}{BG_RED}{WHITE}  ERROR  {WHITE}{BLUE} "
-                f"{current_count}/{total}{WHITE} Status: {RED}invalid JSON "
-                f"for {email}{WHITE}"
+            resp = _session.post(
+                url, json={"input": email}, headers=headers, timeout=10
             )
-            return
+            if resp.status_code != 200:
+                logger.warning("HTTP %d for %s", resp.status_code, email)
+                return EmailResult(
+                    query=email, email=email, status=EmailStatus.UNKNOWN
+                )
+            category = resp.json().get("category", "unknown")
+        except requests.exceptions.RequestException as e:
+            logger.error("request error for %s: %s", email, e)
+            return EmailResult(
+                query=email, email=email, status=EmailStatus.UNKNOWN
+            )
+        except json.JSONDecodeError:
+            logger.error("invalid JSON for %s", email)
+            return EmailResult(
+                query=email, email=email, status=EmailStatus.UNKNOWN
+            )
+
         if category == "disposable":
-            status_val = EmailStatus.INVALID
+            status = EmailStatus.INVALID
         elif category == "unknown":
-            status_val = EmailStatus.UNKNOWN
+            status = EmailStatus.UNKNOWN
         else:
-            status_val = EmailStatus.VALID
+            status = EmailStatus.VALID
 
-        if status_val == EmailStatus.INVALID:
-            color_code, back_color_code = RED, BG_RED
-        elif status_val == EmailStatus.UNKNOWN:
-            color_code, back_color_code = YELLOW, BG_YELLOW
-        else:
-            color_code, back_color_code = GREEN, BG_GREEN
+        return EmailResult(query=email, email=email, status=status)
 
-        with state.lock:
-            state.num += 1
-            current_count = state.num
-            if status_val == EmailStatus.VALID:
-                ok_list.append(email)
-                output_file.write(email + "\n")
+    def execute(
+            self,
+            query: str,
+            api_key: str | None = None,
+            max_workers: int = 20,
+            delay: float | None = None,
+            on_result: callable | None = None,
+    ) -> list[EmailResult]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
 
-        pad = "  " if status_val == EmailStatus.VALID else " "
-        print(
-            f"{SPACE_PREFIX}{back_color_code}{WHITE}{pad}{status_val.value.upper()}"
-            f"{pad}{WHITE}{BLUE} {current_count}/{total}{WHITE} Status: "
-            f"{color_code}{status_val.value}{WHITE} Email: {email}"
-        )
-    except requests.exceptions.RequestException as e_check_email:
-        with state.lock:
-            state.num += 1
-            current_count = state.num
-        print(
-            f"{SPACE_PREFIX}{BG_RED}{WHITE}  ERROR  {WHITE}{BLUE} "
-            f"{current_count}/{total}{WHITE} Status: {RED}"
-            f"{str(e_check_email)}{WHITE} Email: {email}"
-        )
+        key = api_key or settings.get_key("pingutil-api-key")
+        if delay is None:
+            delay = 6.1 if not key else 0.20
 
+        variations = _generate_variations(query)
+        emails = [
+            f"{v}@{domain}"
+            for v in variations
+            for domain in EMAIL_PROVIDERS
+        ]
 
-def mailfinder():
-    """Finds email addresses associated with a given name."""
+        results: list[EmailResult] = []
+        lock = threading.Lock()
+
+        def _worker(email: str) -> None:
+            result = self._check_single(email, key)
+            with lock:
+                results.append(result)
+            if on_result:
+                on_result(result, len(results), len(emails))
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            for email in emails:
+                executor.submit(_worker, email)
+                sleep(delay)
+
+        return results
+
+# ------------------------------------------------------------------
+# Interactive CLI wrapper
+# ------------------------------------------------------------------
+
+def mailfinder() -> list[EmailResult]:
+    """Interactive CLI wrapper — prompts for name, prints progress."""
     full_name = input(f"{SPACE_PREFIX}{BLUE}>{WHITE} enter name:{BLUE} ").lower()
     if not full_name:
-        return
-    email_providers = [
-        "gmail.com", "yahoo.com", "hotmail.com", "aol.com", "msn.com",
-        "comcast.net", "live.com", "rediffmail.com", "ymail.com",
-        "outlook.com", "cox.net", "googlemail.com", "rocketmail.com",
-        "att.net", "facebook.com", "bellsouth.net", "charter.net", "sky.com",
-        "earthlink.net", "optonline.net", "qq.com", "me.com", "gmx.net",
-        "mail.com", "ntlworld.com", "frontiernet.net", "windstream.net",
-        "mac.com", "centurytel.net", "aim.com",
-    ]
-    user_variations = [
-        full_name.replace(" ", ""), full_name.replace(" ", "") + "123",
-        full_name.replace(" ", "") + "1234", full_name.replace("i", "1"),
-        full_name.replace("a", "4"), full_name.replace("e", "3"),
-        full_name.replace("i", "1").replace("a", "4").replace("e", "3"),
-        full_name.replace("i", "1").replace("a", "4"),
-        full_name.replace("i", "1").replace("e", "3"),
-        full_name.replace("a", "4").replace("e", "3"),
-    ]
+        return []
 
-    for name_part in full_name.split(" "):
-        user_variations.append(name_part)
-        user_variations.append(name_part + "123")
-        user_variations.append(name_part + "1234")
+    api_key = settings.get_key("pingutil-api-key")
+    if not api_key:
+        entered = input(
+            f"{SPACE_PREFIX}{WHITE}{BLUE}>{WHITE} pingutil API key "
+            f"(enter to skip, uses demo mode — 10 req/min):{BLUE} "
+        ).strip()
+        if entered:
+            api_key = entered
+            settings.set_key("pingutil-api-key", api_key)
+            save_config()
+
+    if not api_key:
+        print(f"{SPACE_PREFIX}{YELLOW}! demo mode active — rate limited to 10 req/min{WHITE}")
+
+    print(WHITE + LINES_SEPARATOR)
 
     results_file = "result_mailfinder.txt"
-    with open(results_file, "w", encoding="utf-8") as mail_file:
-        valid_emails = []
-        try:
-            api_key = settings.get_key("pingutil-api-key")
-            if not api_key:
-                entered = input(
-                    f"{SPACE_PREFIX}{WHITE}{BLUE}>{WHITE} pingutil API key "
-                    f"(enter to skip, uses demo mode — 10 req/min):{BLUE} "
-                ).strip()
-                if entered:
-                    api_key = entered
-                    settings.set_key("pingutil-api-key", api_key)
-                    save_config()
-            if not api_key:
-                print(f"{SPACE_PREFIX}{YELLOW}! demo mode active — rate limited to 10 req/min{WHITE}")
+    output_fh = open(results_file, "w", encoding="utf-8")
 
-            print(WHITE + LINES_SEPARATOR)
-            state = _State()
-            total = len(email_providers) * len(user_variations)
+    def _on_result(result: EmailResult, current: int, total: int) -> None:
+        if result.status == EmailStatus.VALID:
+            color, bg = GREEN, BG_GREEN
+            pad = "  "
+            output_fh.write(result.email + "\n")
+        elif result.status == EmailStatus.INVALID:
+            color, bg = RED, BG_RED
+            pad = " "
+        else:
+            color, bg = YELLOW, BG_YELLOW
+            pad = " "
+        print(
+            f"{SPACE_PREFIX}{bg}{WHITE}{pad}{result.status.value.upper()}"
+            f"{pad}{WHITE}{BLUE} {current}/{total}{WHITE} Status: "
+            f"{color}{result.status.value}{WHITE} Email: {result.email}"
+        )
 
-            with ThreadPoolExecutor(max_workers=20) as executor:
-                for user_variation in user_variations:
-                    for provider_domain in email_providers:
-                        email_address = f"{user_variation}@{provider_domain}"
-                        executor.submit(
-                            check_email,
-                            email_address, api_key, total,
-                            valid_emails, mail_file, state
-                        )
-                        sleep(6.1 if not api_key else 0.20)
+    try:
+        provider = MailFinderProvider()
+        results = provider.execute(
+            full_name, api_key=api_key, on_result=_on_result
+        )
+    except KeyboardInterrupt:
+        print(f"\r{RED}{SPACE_PREFIX}* Operation aborted by user.{WHITE}")
+        results = []
+    finally:
+        output_fh.close()
 
-        except KeyboardInterrupt:
-            print("ERROR")
-            print(f"\r{RED}{SPACE_PREFIX}* Operation aborted by user.{WHITE}")
+    valid = [r for r in results if r.status == EmailStatus.VALID]
     print(WHITE + LINES_SEPARATOR)
     print(
-        f"{SPACE_PREFIX}{BLUE}>{WHITE} {str(len(valid_emails))} retrieved as: "
+        f"{SPACE_PREFIX}{BLUE}>{WHITE} {len(valid)} retrieved as: "
         f"{YELLOW}{results_file}"
     )
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+    return results

--- a/eagleosint/providers/network.py
+++ b/eagleosint/providers/network.py
@@ -1,5 +1,8 @@
 ﻿"""Network lookups: IP geolocation and HackerTarget API queries."""
+from __future__ import annotations
+
 import ipaddress
+import logging
 import socket
 import subprocess
 import urllib.parse
@@ -11,15 +14,106 @@ from eagleosint.display import (
     RED, YELLOW, BLUE, WHITE,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import session as _session
-from eagleosint.models import IPResult
+from eagleosint.models import IPResult, DomainResult
+
+logger = logging.getLogger(__name__)
 
 API_HACKERTARGET = "https://api.hackertarget.com/{}/?q={}"
 IPINFO_API_URL   = "https://ipinfo.io/{}/json"
 
 
+class IPLocationProvider(BaseProvider):
+    name = "iplocation"
+    version = "1.0.0"
+    description = "IP geolocation via ipinfo.io"
+    category = ProviderCategory.IP
+
+    def validate_query(self, query: str) -> str | None:
+        base = super().validate_query(query)
+        if base:
+            return base
+        try:
+            ipaddress.ip_address(query.strip())
+        except ValueError:
+            return "Invalid IP address"
+        return None
+
+    def execute(self, query: str) -> list[IPResult]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
+
+        try:
+            resp = _session.get(
+                IPINFO_API_URL.format(query.strip()), timeout=10
+            )
+            data = resp.json()
+        except requests.exceptions.RequestException as e:
+            logger.error("ipinfo API error: %s", e)
+            return []
+
+        return [IPResult(
+            query=query,
+            ip=data.get("ip", query),
+            city=data.get("city"),
+            region=data.get("region"),
+            country=data.get("country"),
+            coordinates=data.get("loc"),
+            org=data.get("org"),
+            timezone=data.get("timezone"),
+            hostname=data.get("hostname"),
+            raw=data,
+        )]
+
+class DomainInfoProvider(BaseProvider):
+    name = "network"
+    version = "1.0.0"
+    description = "DNS, WHOIS, and host lookups via HackerTarget API"
+    category = ProviderCategory.DOMAIN
+
+    def execute(self, query: str, query_type: str = "dnslookup") -> list[DomainResult]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
+
+        target = urllib.parse.quote(query.strip(), safe="-._~")
+        if target.split(".")[0].isnumeric():
+            try:
+                target = socket.gethostbyname(target)
+            except socket.gaierror as e:
+                logger.error("hostname resolution error: %s", e)
+                return []
+
+        try:
+            resp = _session.get(
+                API_HACKERTARGET.format(query_type, target),
+                stream=True, timeout=10,
+            )
+            lines = [
+                line.decode("utf-8")
+                for line in resp.iter_lines()
+                if line
+            ]
+        except requests.exceptions.RequestException as e:
+            logger.error("HackerTarget API error: %s", e)
+            return []
+
+        return [DomainResult(
+            query=query,
+            query_type=query_type,
+            records=lines,
+        )]
+
+# ------------------------------------------------------------------
+# Interactive CLI wrappers (unchanged interface for cli.py)
+# ------------------------------------------------------------------
+
 def iplocation() -> IPResult | None:
-    """Retrieves and displays geolocation information for an IP address."""
+    """Interactive CLI wrapper for IP geolocation."""
     try:
         process = subprocess.run(
             ["curl", "ifconfig.co", "--silent"],
@@ -27,70 +121,51 @@ def iplocation() -> IPResult | None:
         )
         local_ip = process.stdout.strip()
         print(f"{SPACE_PREFIX}{BLUE}>{WHITE} local IP: {local_ip}")
-    except subprocess.CalledProcessError as e:
-        print(f"{RED}Error getting local IP: {e}{WHITE}")
-        local_ip = "Unknown"
-    except FileNotFoundError:
-        print(f"{RED}Error: curl command not found.{WHITE}")
-        local_ip = "Unknown"
-    except subprocess.TimeoutExpired:
-        print(f"{RED}Timeout getting local IP.{WHITE}")
-        local_ip = "Unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
 
     ip_address = input(f"{SPACE_PREFIX}{BLUE}>{WHITE} enter IP:{BLUE} ").strip()
-    try:
-        ipaddress.ip_address(ip_address)
-    except ValueError:
-        print(f"{RED}Invalid IP address.{WHITE}")
-        return
+
+    provider = IPLocationProvider()
+    results = provider.execute(ip_address)
+
     print(WHITE + LINES_SEPARATOR)
-    try:
-        req = _session.get(IPINFO_API_URL.format(ip_address), timeout=10).json()
-        for label, key in [
-            ("IP", "ip"), ("CITY", "city"), ("COUNTRY", "country"),
-            ("LOC", "loc"), ("ORG", "org"), ("TIMEZONE", "timezone"),
-        ]:
-            print(f"{SPACE_PREFIX}{BLUE}-{WHITE} {label}: {req.get(key, '')}")
-        ip_result = IPResult(
-            query=ip_address,
-            ip=req.get("ip", ip_address),
-            city=req.get("city"),
-            region=req.get("region"),
-            country=req.get("country"),
-            coordinates=req.get("loc"),
-            org=req.get("org"),
-            timezone=req.get("timezone"),
-            hostname=req.get("hostname"),
-            raw=req,
-        )
-    except requests.exceptions.RequestException as e:
-        print(f"{RED}Error fetching IP information: {e}{WHITE}")
+    if not results:
+        print(f"{RED}No results for '{ip_address}'.{WHITE}")
+        print(WHITE + LINES_SEPARATOR)
+        getpass(SPACE_PREFIX + "press enter for back to previous menu ")
         return None
+
+    result = results[0]
+    for label, value in [
+        ("IP", result.ip), ("CITY", result.city), ("COUNTRY", result.country),
+        ("LOC", result.coordinates), ("ORG", result.org), ("TIMEZONE", result.timezone),
+    ]:
+        print(f"{SPACE_PREFIX}{BLUE}-{WHITE} {label}: {value or ''}")
+
     print(WHITE + LINES_SEPARATOR)
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
-    return ip_result
+    return result
 
-
-def infoga(option):
-    """Retrieves information about a domain or IP address."""
+def infoga(option: str) -> DomainResult | None:
+    """Interactive CLI wrapper for HackerTarget queries."""
     target = input(f"{SPACE_PREFIX}{BLUE}>{WHITE} enter domain or IP:{BLUE} ").strip()
     if not target:
-        return
-    target = urllib.parse.quote(target, safe="-._~")
-    if target.split(".")[0].isnumeric():
-        try:
-            target = socket.gethostbyname(target)
-        except socket.gaierror as e:
-            print(f"{RED}Error resolving hostname: {e}{WHITE}")
-            return
+        return None
+
+    provider = DomainInfoProvider()
+    results = provider.execute(target, query_type=option)
+
     print(WHITE + LINES_SEPARATOR)
-    try:
-        req = _session.get(
-            API_HACKERTARGET.format(option, target), stream=True, timeout=10
-        )
-        for res_line in req.iter_lines():
-            print(f"{SPACE_PREFIX}{BLUE}-{WHITE} {res_line.decode('utf-8')}")
-    except requests.exceptions.RequestException as e:
-        print(f"{RED}Error fetching information: {e}{WHITE}")
+    if not results:
+        print(f"{RED}No results for '{target}'.{WHITE}")
+        print(WHITE + LINES_SEPARATOR)
+        getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+        return None
+
+    for line in results[0].records:
+        print(f"{SPACE_PREFIX}{BLUE}-{WHITE} {line}")
+
     print(WHITE + LINES_SEPARATOR)
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+    return results[0]

--- a/eagleosint/providers/phoneinfo.py
+++ b/eagleosint/providers/phoneinfo.py
@@ -1,4 +1,5 @@
 ﻿"""Phone number information via Veriphone API."""
+from __future__ import annotations
 import json
 import logging
 import urllib.parse

--- a/eagleosint/providers/phoneinfo.py
+++ b/eagleosint/providers/phoneinfo.py
@@ -1,6 +1,8 @@
 ﻿"""Phone number information via Veriphone API."""
 import json
+import logging
 import urllib.parse
+from typing import ClassVar
 from getpass import getpass
 
 import requests
@@ -11,14 +13,63 @@ from eagleosint.display import (
     BG_BLUE, BG_RED,
     SPACE_PREFIX, LINES_SEPARATOR,
 )
+from eagleosint.models import PhoneResult
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import session as _session
+
+logger = logging.getLogger(__name__)
 
 VERIPHONE_API_BASE_URL = "https://api.veriphone.io/v2/verify"
 
+class PhoneInfoProvider(BaseProvider):
+    name = "phoneinfo"
+    version = "1.0.0"
+    description = "Phone number validation and carrier lookup via Veriphone API"
+    category = ProviderCategory.PHONE
+    required_keys: ClassVar[list[str]] = ["veriphone-api-key"]
 
-def phoneinfo():
-    """Retrieves information about a phone number."""
+    def execute(self, query: str, api_key: str | None = None) -> list[PhoneResult]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
+
+        key = api_key or settings.get_key("veriphone-api-key")
+        if not key:
+            logger.error("missing Veriphone API key")
+            return []
+
+        api_url = (
+            f"{VERIPHONE_API_BASE_URL}?phone="
+            f"{urllib.parse.quote(query.strip())}&key={key}"
+        )
+        try:
+            resp = _session.get(api_url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.exceptions.RequestException as e:
+            logger.error("Veriphone API error: %s", e)
+            return []
+        except json.JSONDecodeError:
+            logger.error("invalid JSON from Veriphone API")
+            return []
+
+        return [PhoneResult(
+            query=query,
+            phone=data.get("phone", query),
+            phone_valid=data.get("phone_valid"),
+            country=data.get("country"),
+            country_code=data.get("country_code"),
+            carrier=data.get("carrier"),
+            line_type=data.get("line_type"),
+            international_number=data.get("international_number"),
+            raw=data,
+        )]
+
+def phoneinfo() -> PhoneResult | None:
+    """Interactive CLI wrapper — prompts for number and API key."""
     phone_number = input(f"{SPACE_PREFIX}{BLUE}>{WHITE} enter number:{BLUE} ")
+
     api_key = settings.get_key("veriphone-api-key")
     if not api_key:
         api_key = input(
@@ -27,30 +78,28 @@ def phoneinfo():
         )
         settings.set_key("veriphone-api-key", api_key)
         save_config()
-    if not phone_number:
-        return
+
+    provider = PhoneInfoProvider()
+    results = provider.execute(phone_number, api_key=api_key)
+
     print(WHITE + LINES_SEPARATOR)
-    api_url = (
-        f"{VERIPHONE_API_BASE_URL}?phone="
-        f"{urllib.parse.quote(phone_number.strip())}&key={api_key}"
-    )
-    try:
-        req = _session.get(api_url, timeout=10)
-        req.raise_for_status()
-        res = req.json()
-        for info_key, info_value in res.items():
+    if not results:
+        print(f"{RED}No results for '{phone_number}'.{WHITE}")
+        print(WHITE + LINES_SEPARATOR)
+        getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+        return None
+
+    result = results[0]
+    if result.raw:
+        for info_key, info_value in result.raw.items():
             print(
                 f"{SPACE_PREFIX}{BLUE}-{WHITE} {info_key}"
                 f"{' ' * (23 - len(info_key))}:    {YELLOW}"
                 f"{info_value}{WHITE}"
             )
-    except requests.exceptions.HTTPError as http_err_phone:
-        print(f"{RED}HTTP error fetching phone information: {http_err_phone}{WHITE}")
-    except requests.exceptions.RequestException as e_phone:
-        print(f"{RED}Error fetching phone information: {e_phone}{WHITE}")
-    except json.JSONDecodeError:
-        print(f"{RED}Error decoding JSON response for phone info.{WHITE}")
 
     print(WHITE + LINES_SEPARATOR)
     print(f"{SPACE_PREFIX}{BG_BLUE} DONE {BG_RED} {phone_number} {WHITE}")
+
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+    return result

--- a/eagleosint/providers/userrecon.py
+++ b/eagleosint/providers/userrecon.py
@@ -1,116 +1,169 @@
-﻿import threading
+﻿from __future__ import annotations
+import logging
+import threading
 from getpass import getpass
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
+from typing import Callable, ClassVar
 
 import requests
 
-from eagleosint.config import logger
 from eagleosint.display import (
     RED, GREEN, YELLOW, BLUE, WHITE,
     SPACE_PREFIX, LINES_SEPARATOR, display_progress
 )
+from eagleosint.models import AccountHit, AccountStatus
+from eagleosint.plugin import BaseProvider, ProviderCategory
 from eagleosint.session import HEADERS, session as _session
 
-class _State:
-    __slots__ = ("num", "working", "lock")
-    def __init__(self):
-        self.num = 0
-        self.working = 0
-        self.lock = threading.Lock()
+logger = logging.getLogger(__name__)
 
-def send_req(url, username, state):
-    """Sends a request to a given URL and prints the status code."""
-    try:
-        req = _session.get(url.format(username), headers=HEADERS, timeout=10)
-        req.raise_for_status()
-    except requests.exceptions.HTTPError as http_err:
-        logger.warning("HTTP error for %s: %s", url.format(username), http_err)
-        print(f"{RED}HTTP error for {url.format(username)}: {http_err}{WHITE}")
-        return
-    except requests.exceptions.Timeout:
-        logger.debug("Timeout: %s", url.format(username))
-        print(f"{YELLOW}Timeout for {url.format(username)}{WHITE}")
-        return
-    except requests.exceptions.TooManyRedirects:
-        logger.warning("Too many redirects: %s", url.format(username))
-        print(f"{YELLOW}Too many redirects for {url.format(username)}{WHITE}")
-        return
-    except requests.exceptions.ConnectionError:
-        logger.debug("Connection error: %s", url.format(username))
-        print(f"{YELLOW}Connection error for {url.format(username)}{WHITE}")
-        return
+PLATFORM_URLS = [
+    "https://facebook.com/{}", "https://instagram.com/{}",
+    "https://twitter.com/{}", "https://youtube.com/{}",
+    "https://vimeo.com/{}", "https://github.com/{}",
+    "https://plus.google.com/{}", "https://pinterest.com/{}",
+    "https://flickr.com/people/{}", "https://vk.com/{}",
+    "https://about.me/{}", "https://disqus.com/{}",
+    "https://bitbucket.org/{}", "https://flipboard.com/@{}",
+    "https://medium.com/@{}", "https://hackerone.com/{}",
+    "https://keybase.io/{}", "https://buzzfeed.com/{}",
+    "https://slideshare.net/{}", "https://mixcloud.com/{}",
+    "https://soundcloud.com/{}", "https://badoo.com/en/{}",
+    "https://imgur.com/user/{}", "https://open.spotify.com/user/{}",
+    "https://pastebin.com/u/{}", "https://wattpad.com/user/{}",
+    "https://canva.com/{}", "https://codecademy.com/{}",
+    "https://last.fm/user/{}", "https://blip.fm/{}",
+    "https://dribbble.com/{}", "https://en.gravatar.com/{}",
+    "https://foursquare.com/{}", "https://creativemarket.com/{}",
+    "https://ello.co/{}", "https://cash.me/{}", "https://angel.co/{}",
+    "https://500px.com/{}", "https://houzz.com/user/{}",
+    "https://tripadvisor.com/members/{}",
+    "https://kongregate.com/accounts/{}", "https://{}.blogspot.com/",
+    "https://{}.tumblr.com/", "https://{}.wordpress.com/",
+    "https://{}.devianart.com/", "https://{}.slack.com/",
+    "https://{}.livejournal.com/", "https://{}.newgrounds.com/",
+    "https://{}.hubpages.com", "https://{}.contently.com",
+    "https://steamcommunity.com/id/{}",
+    "https://www.wikipedia.org/wiki/User:{}",
+    "https://www.freelancer.com/u/{}", "https://www.dailymotion.com/{}",
+    "https://www.etsy.com/shop/{}", "https://www.scribd.com/{}",
+    "https://www.patreon.com/{}", "https://www.behance.net/{}",
+    "https://www.goodreads.com/{}", "https://www.gumroad.com/{}",
+    "https://www.instructables.com/member/{}",
+    "https://www.codementor.io/{}", "https://www.reverbnation.com/{}",
+    "https://www.designspiration.net/{}", "https://www.bandcamp.com/{}",
+    "https://www.colourlovers.com/love/{}", "https://www.ifttt.com/p/{}",
+    "https://www.trakt.tv/users/{}", "https://www.okcupid.com/profile/{}",
+    "https://www.trip.skyscanner.com/user/{}",
+    "http://www.zone-h.org/archive/notifier={}",
+]
 
-    color_code = GREEN if req.status_code == 200 else (RED if req.status_code == 404 else YELLOW)
+class UserReconProvider(BaseProvider):
+    name = "userrecon"
+    version = "1.0.0"
+    description = "Username reconnaissance across 71 platforms"
+    category = ProviderCategory.USERNAME
 
-    with state.lock:
-        state.num += 1
-        if req.status_code == 200:
-            state.working += 1
-        num = state.num
-        working = state.working
+    def _check_platform(self, url_template: str, username: str) -> AccountHit:
+        """Check a single platform for the username"""
+        url = url_template.format(username)
+        try:
+            resp = _session.get(url, headers=HEADERS, timeout=10)
+            resp.raise_for_status()
+            status = AccountStatus.FOUND if resp.status_code == 200 else AccountStatus.NOT_FOUND
+            return AccountHit(
+                query=username,
+                platform=url_template.split("/")[2],
+                url=url,
+                status=status,
+                http_status_code=resp.status_code,
+            )
+        except requests.exceptions.HTTPError:
+            return AccountHit(
+                query=username,
+                platform=url_template.split("/")[2],
+                url=url,
+                status=AccountStatus.NOT_FOUND,
+                http_status_code=getattr(resp, "status_code", 0),
+            )
+        except requests.exceptions.RequestException:
+            return AccountHit(
+                query=username,
+                platform=url_template.split("/")[2],
+                url=url,
+                status=AccountStatus.UNKNOWN,
+                http_status_code=0,
+            )
 
-    display_progress(num, 71, f"FOUND: {working}")
-    print(
-        f"  {SPACE_PREFIX}{BLUE}[{color_code}{req.status_code}{BLUE}] "
-        f"{num}/71 {WHITE}{url.format(username)}"
-    )
+    def execute(
+        self,
+        query: str,
+        max_workers: int = 20,
+        delay: float = 0.7,
+        on_result: Callable | None = None,
+    ) -> list[AccountHit]:
+        error = self.validate_query(query)
+        if error:
+            logger.warning("invalid query: %s", error)
+            return []
 
-def userrecon():
-    """Performs username reconnaissance across various platforms."""
-    username_to_check = input(
+        username = query.lower().strip()
+        results: list[AccountHit] = []
+        lock = threading.Lock()
+        total = len(PLATFORM_URLS)
+
+        def _worker(url_template: str) -> None:
+            hit = self._check_platform(url_template, username)
+            with lock:
+                results.append(hit)
+            if on_result:
+                on_result(hit, len(results), total)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            for url_template in PLATFORM_URLS:
+                executor.submit(_worker, url_template)
+                sleep(delay)
+
+        return results
+
+# ------------------------------------------------------------------
+# Interactive CLI wrapper
+# ------------------------------------------------------------------
+
+def userrecon() -> list[AccountHit]:
+    """Interactive CLI wrapper — prompts for username, prints progress."""
+    username = input(
         f"{SPACE_PREFIX}{WHITE}{BLUE}>{WHITE} enter username:{BLUE} "
     ).lower()
-    if not username_to_check:
-        return
-    url_list = [
-        "https://facebook.com/{}", "https://instagram.com/{}",
-        "https://twitter.com/{}", "https://youtube.com/{}",
-        "https://vimeo.com/{}", "https://github.com/{}",
-        "https://plus.google.com/{}", "https://pinterest.com/{}",
-        "https://flickr.com/people/{}", "https://vk.com/{}",
-        "https://about.me/{}", "https://disqus.com/{}",
-        "https://bitbucket.org/{}", "https://flipboard.com/@{}",
-        "https://medium.com/@{}", "https://hackerone.com/{}",
-        "https://keybase.io/{}", "https://buzzfeed.com/{}",
-        "https://slideshare.net/{}", "https://mixcloud.com/{}",
-        "https://soundcloud.com/{}", "https://badoo.com/en/{}",
-        "https://imgur.com/user/{}", "https://open.spotify.com/user/{}",
-        "https://pastebin.com/u/{}", "https://wattpad.com/user/{}",
-        "https://canva.com/{}", "https://codecademy.com/{}",
-        "https://last.fm/user/{}", "https://blip.fm/{}",
-        "https://dribbble.com/{}", "https://en.gravatar.com/{}",
-        "https://foursquare.com/{}", "https://creativemarket.com/{}",
-        "https://ello.co/{}", "https://cash.me/{}", "https://angel.co/{}",
-        "https://500px.com/{}", "https://houzz.com/user/{}",
-        "https://tripadvisor.com/members/{}",
-        "https://kongregate.com/accounts/{}", "https://{}.blogspot.com/",
-        "https://{}.tumblr.com/", "https://{}.wordpress.com/",
-        "https://{}.devianart.com/", "https://{}.slack.com/",
-        "https://{}.livejournal.com/", "https://{}.newgrounds.com/",
-        "https://{}.hubpages.com", "https://{}.contently.com",
-        "https://steamcommunity.com/id/{}",
-        "https://www.wikipedia.org/wiki/User:{}",
-        "https://www.freelancer.com/u/{}", "https://www.dailymotion.com/{}",
-        "https://www.etsy.com/shop/{}", "https://www.scribd.com/{}",
-        "https://www.patreon.com/{}", "https://www.behance.net/{}",
-        "https://www.goodreads.com/{}", "https://www.gumroad.com/{}",
-        "https://www.instructables.com/member/{}",
-        "https://www.codementor.io/{}", "https://www.reverbnation.com/{}",
-        "https://www.designspiration.net/{}", "https://www.bandcamp.com/{}",
-        "https://www.colourlovers.com/love/{}", "https://www.ifttt.com/p/{}",
-        "https://www.trakt.tv/users/{}", "https://www.okcupid.com/profile/{}",
-        "https://www.trip.skyscanner.com/user/{}",
-        "http://www.zone-h.org/archive/notifier={}",
-    ]
+    if not username:
+        return []
 
-    state = _State()
+    found_count = 0
+    found_lock = threading.Lock()
+
+    def _on_result(hit: AccountHit, current: int, total: int) -> None:
+        nonlocal found_count
+        if hit.status == AccountStatus.FOUND:
+            color = GREEN
+            with found_lock:
+                found_count += 1
+        elif hit.status == AccountStatus.NOT_FOUND:
+            color = RED
+        else:
+            color = YELLOW
+
+        display_progress(current, total, f"FOUND: {found_count}")
+        print(
+            f"  {SPACE_PREFIX}{BLUE}[{color}{hit.http_status_code}{BLUE}] "
+            f"{current}/{total} {WHITE}{hit.url}"
+        )
+
     print(WHITE + LINES_SEPARATOR)
-    with ThreadPoolExecutor(max_workers=20) as executor:
-        for site_url in url_list:
-            executor.submit(send_req, site_url, username_to_check, state)
-            sleep(0.7)
+    provider = UserReconProvider()
+    results = provider.execute(username, on_result=_on_result)
 
     print()
     print(WHITE + LINES_SEPARATOR)
     getpass(SPACE_PREFIX + "press enter for back to previous menu ")
+    return results

--- a/tests/test_bitly.py
+++ b/tests/test_bitly.py
@@ -4,18 +4,62 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 
-from eagleosint.providers.bitly import bypass_bitly
+from eagleosint.providers.bitly import BitlyProvider, bypass_bitly
+
+
+class TestBitlyProvider:
+    """Tests for the provider class (no UI)."""
+
+    def test_valid_url_returns_expansion(self, monkeypatch):
+        mock_resp = MagicMock()
+        mock_resp.text = '<a href="https://example.com">click</a>'
+        monkeypatch.setattr(
+            "eagleosint.providers.bitly._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        provider = BitlyProvider()
+        results = provider.execute("https://bit.ly/abc123")
+        assert len(results) == 1
+        assert results[0].original_url == "https://example.com"
+        assert results[0].short_url == "https://bit.ly/abc123"
+        assert results[0].source == "bitly"
+
+    def test_invalid_url_returns_empty(self):
+        provider = BitlyProvider()
+        assert provider.execute("not-a-url") == []
+
+    def test_empty_query_returns_empty(self):
+        provider = BitlyProvider()
+        assert provider.execute("") == []
+
+    def test_network_error_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.bitly._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = BitlyProvider()
+        assert provider.execute("https://bit.ly/abc123") == []
+
+    def test_parse_error_returns_empty(self, monkeypatch):
+        mock_resp = MagicMock()
+        mock_resp.text = "<html><body>no links here</body></html>"
+        monkeypatch.setattr(
+            "eagleosint.providers.bitly._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        provider = BitlyProvider()
+        assert provider.execute("https://bit.ly/abc123") == []
+
+    def test_validate_query_rejects_bad_scheme(self):
+        provider = BitlyProvider()
+        assert provider.validate_query("ftp://bit.ly/abc") is not None
+        assert provider.validate_query("https://bit.ly/abc") is None
 
 
 class TestBypassBitly:
-    def test_invalid_url_prints_error(self, capsys, monkeypatch):
-        monkeypatch.setattr("builtins.input", lambda _: "not-a-url")
-        monkeypatch.setattr("eagleosint.providers.bitly.getpass", lambda _: "")
-        bypass_bitly()
-        captured = capsys.readouterr()
-        assert "Invalid" in captured.out
+    """Tests for the interactive CLI wrapper."""
 
-    def test_valid_url_resolves(self, capsys, monkeypatch):
+    def test_valid_url_prints_result(self, capsys, monkeypatch):
         mock_resp = MagicMock()
         mock_resp.text = '<a href="https://example.com">click</a>'
         monkeypatch.setattr(
@@ -28,13 +72,10 @@ class TestBypassBitly:
         captured = capsys.readouterr()
         assert "example.com" in captured.out
 
-    def test_request_error_prints_message(self, capsys, monkeypatch):
-        monkeypatch.setattr("builtins.input", lambda _: "https://bit.ly/abc123")
-        monkeypatch.setattr(
-            "eagleosint.providers.bitly._session.get",
-            MagicMock(side_effect=requests.exceptions.ConnectionError),
-        )
+    def test_invalid_url_shows_no_results(self, capsys, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda _: "not-a-url")
         monkeypatch.setattr("eagleosint.providers.bitly.getpass", lambda _: "")
-        bypass_bitly()
+        result = bypass_bitly()
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "No results" in captured.out
+        assert result is None

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4,14 +4,64 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from eagleosint.providers.github import GITHUB_API_URL, github_lookup
+from eagleosint.providers.github import GITHUB_API_URL, GithubProvider, github_lookup
 
 
-class TestGithubLookup:
+class TestGithubProvider:
+    """Tests for the provider class (no UI, no input)."""
+
     def _mock_response(self, data: dict, status: int = 200):
         mock_resp = MagicMock()
         mock_resp.status_code = status
         mock_resp.json.return_value = data
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def test_valid_username_prints_table(self, capsys, monkeypatch):
+        fake_data = {"login": "octocat", "name": "The Octocat", "public_repos": 8}
+        monkeypatch.setattr(
+            "eagleosint.providers.github._session.get",
+            lambda *a, **kw: self._mock_response(fake_data),
+        )
+        provider = GithubProvider()
+        results = provider.execute("octocat")
+        assert len(results) == 1
+        assert results[0].username == "octocat"
+        assert results[0].name == "The Octocat"
+        assert results[0].source == "github"
+
+    def test_invalid_username_returns_empty(self):
+        provider = GithubProvider()
+        results = provider.execute("!!!invalid!!!")
+        assert results == []
+
+    def test_empty_query_returns_empty(self):
+        provider = GithubProvider()
+        assert provider.execute("") == []
+        assert provider.execute("   ") == []
+
+    def test_network_error_returns_empty(self, monkeypatch):
+        import requests
+        monkeypatch.setattr(
+            "eagleosint.providers.github._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = GithubProvider()
+        results = provider.execute("octocat")
+        assert results == []
+
+    def test_api_url_template(self):
+        assert GITHUB_API_URL.format("octocat") == "https://api.github.com/users/octocat"
+
+
+class TestGithubLookup:
+    """Tests for the interactive CLI wrapper."""
+
+    def _mock_response(self, data: dict, status: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status
+        mock_resp.json.return_value = data
+        mock_resp.raise_for_status.return_value = None
         return mock_resp
 
     def test_valid_username_prints_table(self, capsys, monkeypatch):
@@ -26,23 +76,10 @@ class TestGithubLookup:
         captured = capsys.readouterr()
         assert "octocat" in captured.out
 
-    def test_invalid_username_prints_error(self, capsys, monkeypatch):
+    def test_invalid_username_shows_no_results(self, capsys, monkeypatch):
         monkeypatch.setattr("builtins.input", lambda _: "!!!invalid!!!")
-        github_lookup()
-        captured = capsys.readouterr()
-        assert "Invalid" in captured.out
-
-    def test_api_url_template(self):
-        assert GITHUB_API_URL.format("octocat") == "https://api.github.com/users/octocat"
-
-    def test_network_error_prints_message(self, capsys, monkeypatch):
-        import requests
-        monkeypatch.setattr("builtins.input", lambda _: "octocat")
-        monkeypatch.setattr(
-            "eagleosint.providers.github._session.get",
-            MagicMock(side_effect=requests.exceptions.ConnectionError),
-        )
         monkeypatch.setattr("eagleosint.providers.github.getpass", lambda _: "")
-        github_lookup()
+        result = github_lookup()
         captured = capsys.readouterr()
-        assert "Error" in captured.out
+        assert "No results" in captured.out
+        assert result is None

--- a/tests/test_godorker.py
+++ b/tests/test_godorker.py
@@ -1,0 +1,76 @@
+"""Tests for eagleosint.providers.godorker."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from eagleosint.providers.godorker import GoDorkerProvider
+from eagleosint.models import DorkResult
+
+
+class TestGoDorkerProvider:
+
+    def test_empty_query_returns_empty(self):
+        provider = GoDorkerProvider()
+        assert provider.execute("") == []
+
+    def test_execute_returns_dork_results(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker.search",
+            lambda q, **kw: ["https://example.com", "https://test.com"],
+        )
+        mock_resp = MagicMock()
+        mock_resp.content = b"<html><head><title>Example</title></head></html>"
+        mock_resp.raise_for_status.return_value = None
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        provider = GoDorkerProvider()
+        results = provider.execute("inurl:test")
+        assert len(results) == 2
+        assert results[0].url == "https://example.com"
+        assert results[0].title == "Example"
+        assert results[0].source == "godorker"
+
+    def test_search_error_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker.search",
+            MagicMock(side_effect=Exception("blocked")),
+        )
+        provider = GoDorkerProvider()
+        results = provider.execute("inurl:test")
+        assert results == []
+
+    def test_fetch_title_failure_returns_none_title(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker.search",
+            lambda q, **kw: ["https://down.com"],
+        )
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = GoDorkerProvider()
+        results = provider.execute("inurl:test")
+        assert len(results) == 1
+        assert results[0].title is None
+
+    def test_on_result_callback_called(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker.search",
+            lambda q, **kw: ["https://example.com"],
+        )
+        mock_resp = MagicMock()
+        mock_resp.content = b"<html><head><title>T</title></head></html>"
+        mock_resp.raise_for_status.return_value = None
+        monkeypatch.setattr(
+            "eagleosint.providers.godorker._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        called = []
+        provider = GoDorkerProvider()
+        provider.execute("test", on_result=lambda r: called.append(r))
+        assert len(called) == 1

--- a/tests/test_mailfinder.py
+++ b/tests/test_mailfinder.py
@@ -1,1 +1,120 @@
-# TODO Mailfinder Tests
+"""Tests for eagleosint.providers.mailfinder."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from eagleosint.providers.mailfinder import (
+    MailFinderProvider, _generate_variations, EMAIL_PROVIDERS,
+)
+from eagleosint.models import EmailStatus
+
+
+class TestGenerateVariations:
+
+    def test_single_name_produces_variations(self):
+        results = _generate_variations("john")
+        assert "john" in results
+        assert "john123" in results
+        assert "john1234" in results
+
+    def test_full_name_has_no_spaces(self):
+        results = _generate_variations("John Doe")
+        assert all(" " not in v for v in results)
+        assert "johndoe" in results
+
+    def test_leet_replacements(self):
+        results = _generate_variations("alice")
+        assert "al1ce" in results   # i->1
+        assert "4lice" in results   # a->4
+        assert "alic3" in results   # e->3
+
+
+class TestMailFinderProvider:
+
+    def _mock_response(self, category: str, status_code: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.json.return_value = {"category": category}
+        return mock_resp
+
+    def test_single_valid_email(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("valid"),
+        )
+        provider = MailFinderProvider()
+        result = provider._check_single("test@gmail.com", api_key="key")
+        assert result.status == EmailStatus.VALID
+        assert result.email == "test@gmail.com"
+
+    def test_single_disposable_email(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("disposable"),
+        )
+        provider = MailFinderProvider()
+        result = provider._check_single("x@temp.com", api_key="key")
+        assert result.status == EmailStatus.INVALID
+
+    def test_single_unknown_category(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("unknown"),
+        )
+        provider = MailFinderProvider()
+        result = provider._check_single("x@test.com", api_key="key")
+        assert result.status == EmailStatus.UNKNOWN
+
+    def test_http_error_returns_unknown(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("valid", status_code=429),
+        )
+        provider = MailFinderProvider()
+        result = provider._check_single("x@test.com", api_key="key")
+        assert result.status == EmailStatus.UNKNOWN
+
+    def test_network_error_returns_unknown(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = MailFinderProvider()
+        result = provider._check_single("x@test.com", api_key="key")
+        assert result.status == EmailStatus.UNKNOWN
+
+    def test_empty_query_returns_empty(self):
+        provider = MailFinderProvider()
+        assert provider.execute("") == []
+
+    def test_execute_calls_check_for_each_email(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("valid"),
+        )
+        provider = MailFinderProvider()
+        results = provider.execute(
+            "test", api_key="key", max_workers=2, delay=0
+        )
+        expected_count = len(_generate_variations("test")) * len(EMAIL_PROVIDERS)
+        assert len(results) == expected_count
+        assert all(r.status == EmailStatus.VALID for r in results)
+
+    def test_on_result_callback_called(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.mailfinder._session.post",
+            lambda *a, **kw: self._mock_response("valid"),
+        )
+        called = []
+        provider = MailFinderProvider()
+        provider.execute(
+            "ab",
+            api_key="key",
+            max_workers=2,
+            delay=0,
+            on_result=lambda r, c, t: called.append(c),
+        )
+        assert len(called) > 0

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,22 +1,93 @@
 """Tests for eagleosint.providers.network."""
 from unittest.mock import MagicMock
 
+import pytest
 import requests
 
-from eagleosint.providers.network import API_HACKERTARGET, IPINFO_API_URL, infoga, iplocation
+from eagleosint.providers.network import (
+    API_HACKERTARGET, IPINFO_API_URL,
+    IPLocationProvider, DomainInfoProvider,
+    iplocation, infoga,
+)
 
 
-class TestIplocation:
-    def test_invalid_ip_prints_error(self, capsys, monkeypatch):
+class TestIPLocationProvider:
+
+    def _mock_response(self, data: dict):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = data
+        return mock_resp
+
+    def test_valid_ip_returns_result(self, monkeypatch):
+        fake_data = {
+            "ip": "8.8.8.8", "city": "Mountain View",
+            "country": "US", "loc": "37,-122",
+            "org": "Google", "timezone": "America/Los_Angeles",
+        }
         monkeypatch.setattr(
-            "subprocess.run", MagicMock(side_effect=FileNotFoundError)
+            "eagleosint.providers.network._session.get",
+            lambda *a, **kw: self._mock_response(fake_data),
         )
-        monkeypatch.setattr("builtins.input", lambda _: "not-an-ip")
-        iplocation()
-        captured = capsys.readouterr()
-        assert "Invalid" in captured.out
+        provider = IPLocationProvider()
+        results = provider.execute("8.8.8.8")
+        assert len(results) == 1
+        assert results[0].ip == "8.8.8.8"
+        assert results[0].city == "Mountain View"
+        assert results[0].source == "network"
 
-    def test_valid_ip_calls_api(self, capsys, monkeypatch):
+    def test_invalid_ip_returns_empty(self):
+        provider = IPLocationProvider()
+        assert provider.execute("not-an-ip") == []
+
+    def test_empty_query_returns_empty(self):
+        provider = IPLocationProvider()
+        assert provider.execute("") == []
+
+    def test_network_error_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.network._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = IPLocationProvider()
+        assert provider.execute("8.8.8.8") == []
+
+
+class TestDomainInfoProvider:
+
+    def _mock_response(self, lines: list[bytes]):
+        mock_resp = MagicMock()
+        mock_resp.iter_lines.return_value = lines
+        return mock_resp
+
+    def test_valid_domain_returns_records(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.network._session.get",
+            lambda *a, **kw: self._mock_response(
+                [b"A 93.184.216.34", b"MX mail.example.com"]
+            ),
+        )
+        provider = DomainInfoProvider()
+        results = provider.execute("example.com", query_type="dnslookup")
+        assert len(results) == 1
+        assert results[0].query_type == "dnslookup"
+        assert "A 93.184.216.34" in results[0].records
+
+    def test_empty_query_returns_empty(self):
+        provider = DomainInfoProvider()
+        assert provider.execute("") == []
+
+    def test_network_error_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.network._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = DomainInfoProvider()
+        assert provider.execute("example.com") == []
+
+
+class TestIplocationCLI:
+
+    def test_valid_ip_prints_info(self, capsys, monkeypatch):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "ip": "8.8.8.8", "city": "Mountain View",
@@ -35,6 +106,17 @@ class TestIplocation:
         iplocation()
         captured = capsys.readouterr()
         assert "8.8.8.8" in captured.out
+
+    def test_invalid_ip_shows_no_results(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "subprocess.run", MagicMock(side_effect=FileNotFoundError)
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "not-an-ip")
+        monkeypatch.setattr("eagleosint.providers.network.getpass", lambda _: "")
+        result = iplocation()
+        captured = capsys.readouterr()
+        assert "No results" in captured.out
+        assert result is None
 
 
 class TestApiUrlTemplates:

--- a/tests/test_phoneinfo.py
+++ b/tests/test_phoneinfo.py
@@ -1,0 +1,74 @@
+"""Tests for eagleosint.providers.phoneinfo."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from eagleosint.providers.phoneinfo import PhoneInfoProvider
+
+
+class TestPhoneInfoProvider:
+
+    def _mock_response(self, data: dict):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = data
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def test_valid_phone_returns_result(self, monkeypatch):
+        fake_data = {
+            "phone": "+391234567890",
+            "phone_valid": True,
+            "country": "Italy",
+            "country_code": "IT",
+            "carrier": "Vodafone",
+            "line_type": "mobile",
+            "international_number": "+391234567890",
+        }
+        monkeypatch.setattr(
+            "eagleosint.providers.phoneinfo._session.get",
+            lambda *a, **kw: self._mock_response(fake_data),
+        )
+        provider = PhoneInfoProvider()
+        results = provider.execute("+391234567890", api_key="test-key")
+        assert len(results) == 1
+        assert results[0].phone == "+391234567890"
+        assert results[0].country == "Italy"
+        assert results[0].source == "phoneinfo"
+
+    def test_empty_query_returns_empty(self):
+        provider = PhoneInfoProvider()
+        assert provider.execute("", api_key="test-key") == []
+
+    def test_missing_api_key_returns_empty(self, monkeypatch):
+        from unittest.mock import MagicMock
+        mock_settings = MagicMock()
+        mock_settings.get_key.return_value = None
+        monkeypatch.setattr(
+            "eagleosint.providers.phoneinfo.settings",
+            mock_settings,
+        )
+        provider = PhoneInfoProvider()
+        assert provider.execute("+391234567890") == []
+
+    def test_network_error_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.phoneinfo._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = PhoneInfoProvider()
+        assert provider.execute("+391234567890", api_key="test-key") == []
+
+    def test_json_error_returns_empty(self, monkeypatch):
+        import json as _json
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.side_effect = _json.JSONDecodeError("bad", "", 0)
+        monkeypatch.setattr(
+            "eagleosint.providers.phoneinfo._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        provider = PhoneInfoProvider()
+        assert provider.execute("+391234567890", api_key="test-key") == []

--- a/tests/test_userrecon.py
+++ b/tests/test_userrecon.py
@@ -1,0 +1,82 @@
+"""Tests for eagleosint.providers.userrecon."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from eagleosint.providers.userrecon import (
+    UserReconProvider, PLATFORM_URLS,
+)
+from eagleosint.models import AccountStatus
+
+
+class TestUserReconProvider:
+
+    def _mock_response(self, status_code: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def test_found_platform_returns_found(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.userrecon._session.get",
+            lambda *a, **kw: self._mock_response(200),
+        )
+        provider = UserReconProvider()
+        hit = provider._check_platform("https://github.com/{}", "testuser")
+        assert hit.status == AccountStatus.FOUND
+        assert hit.url == "https://github.com/testuser"
+        assert hit.platform == "github.com"
+
+    def test_http_error_returns_not_found(self, monkeypatch):
+        mock_resp = self._mock_response(404)
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError
+        monkeypatch.setattr(
+            "eagleosint.providers.userrecon._session.get",
+            lambda *a, **kw: mock_resp,
+        )
+        provider = UserReconProvider()
+        hit = provider._check_platform("https://github.com/{}", "nouser")
+        assert hit.status == AccountStatus.NOT_FOUND
+
+    def test_connection_error_returns_unknown(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.userrecon._session.get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError),
+        )
+        provider = UserReconProvider()
+        hit = provider._check_platform("https://github.com/{}", "testuser")
+        assert hit.status == AccountStatus.UNKNOWN
+        assert hit.http_status_code == 0
+
+    def test_empty_query_returns_empty(self):
+        provider = UserReconProvider()
+        assert provider.execute("") == []
+
+    def test_execute_returns_results_for_all_platforms(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.userrecon._session.get",
+            lambda *a, **kw: self._mock_response(200),
+        )
+        provider = UserReconProvider()
+        results = provider.execute("testuser", max_workers=5, delay=0)
+        assert len(results) == len(PLATFORM_URLS)
+
+    def test_on_result_callback_called(self, monkeypatch):
+        monkeypatch.setattr(
+            "eagleosint.providers.userrecon._session.get",
+            lambda *a, **kw: self._mock_response(200),
+        )
+        called = []
+        provider = UserReconProvider()
+        provider.execute(
+            "testuser", max_workers=5, delay=0,
+            on_result=lambda hit, c, t: called.append(hit),
+        )
+        assert len(called) == len(PLATFORM_URLS)
+
+    def test_platform_urls_list_not_empty(self):
+        assert len(PLATFORM_URLS) == 71


### PR DESCRIPTION
## Summary
- Migrated 8 providers to BaseProvider ABC: GitHubProvider, BitlyProvider, PhoneInfoProvider, IPLocationProvider, DomainInfoProvider, MailFinderProvider, UserReconProvider, GoDorkerProvider
- Each provider implements execute(query) -> list[ProviderResult] with business logic separated from CLI I/O
- Interactive CLI wrappers preserved as thin functions calling provider classes
- Errors logged via logging instead of printed in provider logic
- Added comprehensive unit tests for all migrated providers
- Facebook and TempMail left unmigrated (deprecated API / polling pattern)

## Test plan
- [x] All tests pass (python -m pytest tests/ -v)
- [x] Each provider tested: valid input, invalid input, empty query, network errors
- [x] No changes to cli.py imports — backward compatible