### PR TITLE
Add PII masking with --show-pii flag (#14)

### DIFF
--- a/eagleosint/cli.py
+++ b/eagleosint/cli.py
@@ -164,15 +164,16 @@ def _write_output(
     results: list,
     fmt: str,
     filepath: str | None,
+    show_pii: bool = False
 ) -> None:
     """Write structured output to file or stdout."""
     from eagleosint.output import write_results
     if filepath:
         with open(filepath, "w", encoding="utf-8") as fh:
-            write_results(results, fmt, fh)
+            write_results(results, fmt, fh, show_pii=show_pii)
         print(f"{BLUE}>{WHITE} output written to {filepath}")
     else:
-        write_results(results, fmt)
+        write_results(results, fmt, show_pii=show_pii)
 
 @click.group(
     invoke_without_command=True,
@@ -195,12 +196,14 @@ def main(ctx: click.Context) -> None:
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save results to this investigation ID.")
-def cmd_userrecon(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_userrecon(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Username reconnaissance across 71 platforms."""
     print(LOGO)
     results = userrecon()
     if output and results:
-        _write_output(results, output, output_file)
+        _write_output(results, output, output_file, show_pii=show_pii)
     if save_to and results:
         from eagleosint.storage import save_result
         for r in results:
@@ -221,12 +224,14 @@ def cmd_facedumper() -> None:
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save results to this investigation ID.")
-def cmd_mailfinder(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_mailfinder(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Find email addresses from a name."""
     print(LOGO)
     results = mailfinder()
     if output and results:
-        _write_output(results, output, output_file)
+        _write_output(results, output, output_file, show_pii=show_pii)
     if save_to and results:
         from eagleosint.storage import save_result
         for r in results:
@@ -240,12 +245,14 @@ def cmd_mailfinder(output: str | None, output_file: str | None, save_to: str | N
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save results to this investigation ID.")
-def cmd_godorker(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_godorker(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Google dorking with result scraping."""
     print(LOGO)
     results = godorker()
     if output and results:
-        _write_output(results, output, output_file)
+        _write_output(results, output, output_file, show_pii=show_pii)
     if save_to and results:
         from eagleosint.storage import save_result
         for r in results:
@@ -259,12 +266,14 @@ def cmd_godorker(output: str | None, output_file: str | None, save_to: str | Non
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_phoneinfo(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_phoneinfo(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Phone number information and validation."""
     print(LOGO)
     result = phoneinfo()
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -277,12 +286,14 @@ def cmd_phoneinfo(output: str | None, output_file: str | None, save_to: str | No
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_dns(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_dns(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """DNS lookup for a domain or IP."""
     print(LOGO)
     result = infoga("dnslookup")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -295,12 +306,14 @@ def cmd_dns(output: str | None, output_file: str | None, save_to: str | None) ->
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_whois(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_whois(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """WHOIS lookup for a domain."""
     print(LOGO)
     result = infoga("whois")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -313,12 +326,14 @@ def cmd_whois(output: str | None, output_file: str | None, save_to: str | None) 
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_subnet(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_subnet(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Subnet / network calculator."""
     print(LOGO)
     result = infoga("subnetcalc")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -331,12 +346,14 @@ def cmd_subnet(output: str | None, output_file: str | None, save_to: str | None)
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_hostfinder(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_hostfinder(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Find hosts for a domain."""
     print(LOGO)
     result = infoga("hostsearch")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -349,12 +366,14 @@ def cmd_hostfinder(output: str | None, output_file: str | None, save_to: str | N
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_dnsfinder(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_dnsfinder(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """DNS finder via MTR."""
     print(LOGO)
     result = infoga("mtr")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -367,12 +386,14 @@ def cmd_dnsfinder(output: str | None, output_file: str | None, save_to: str | No
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_riplookup(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_riplookup(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Reverse IP lookup."""
     print(LOGO)
     result = infoga("reverseiplookup")
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -421,12 +442,14 @@ def cmd_investigation_list() -> None:
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_iplocation(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_iplocation(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """IP address geolocation."""
     print(LOGO)
     result = iplocation()
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -440,12 +463,14 @@ def cmd_iplocation(output: str | None, output_file: str | None, save_to: str | N
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_bitly(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_bitly(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """Resolve and bypass Bitly short URLs."""
     print(LOGO)
     result = bypass_bitly()
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)
@@ -460,12 +485,14 @@ def cmd_bitly(output: str | None, output_file: str | None, save_to: str | None) 
               help="Write output to this file path.")
 @click.option("--save-to", "save_to", default=None,
               help="Save result to this investigation ID.")
-def cmd_github(output: str | None, output_file: str | None, save_to: str | None) -> None:
+@click.option("--show-pii", is_flag=True, default=False,
+              help="Show unmasked PII in output.")
+def cmd_github(output: str | None, output_file: str | None, save_to: str | None, show_pii: bool) -> None:
     """GitHub user profile lookup."""
     print(LOGO)
     result = github_lookup()
     if output and result:
-        _write_output([result], output, output_file)
+        _write_output([result], output, output_file, show_pii=show_pii)
     if save_to and result:
         from eagleosint.storage import save_result
         save_result(save_to, result)

--- a/eagleosint/masking.py
+++ b/eagleosint/masking.py
@@ -1,0 +1,65 @@
+"""PII masking utilities for provider results."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from eagleosint.models import ProviderResult
+
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+_PHONE_RE = re.compile(r"\+?\d[\d\s\-()]{6,}\d")
+_IP_RE = re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+
+def mask_email(value: str) -> str:
+    local, domain = value.split("@", 1)
+    parts = domain.rsplit(".", 1)
+    masked_local = local[:3] + "***" if len(local) > 3 else local[0] + "***"
+    masked_domain = parts[0][:2] + "***." + parts[1] if len(parts) == 2 else "***"
+    return f"{masked_local}@{masked_domain}"
+
+def mask_phone(value: str) -> str:
+    digits = re.sub(r"\D", "", value)
+    if len(digits) <= 4:
+        return value
+    return digits[:3] + "*" * (len(digits) - 6) + digits[-3:]
+
+def mask_ip(value: str) -> str:
+    octets = value.split(".")
+    if len(octets) == 4:
+        return f"{octets[0]}.{octets[1]}.*.*"
+    return value
+
+def mask_hostname(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) >= 2:
+        return parts[0][:3] + "***." + parts[-1]
+    return value[:3] + "***"
+
+def mask_string(text: str) -> str:
+    text = _EMAIL_RE.sub(lambda m: mask_email(m.group()), text)
+    text = _PHONE_RE.sub(lambda m: mask_phone(m.group()), text)
+    text = _IP_RE.sub(lambda m: mask_ip(m.group()), text)
+    return text
+
+_PII_FIELDS = {"email", "phone", "ip", "international_number", "hostname", "coordinates"}
+
+def mask_value(value: Any, field_name: str = "") -> Any:
+    if isinstance(value, str):
+        if field_name == "hostname":
+            return mask_hostname(value)
+        if field_name in _PII_FIELDS:
+            return mask_string(value)
+        return value
+    if isinstance(value, list):
+        return [mask_value(item, field_name) for item in value]
+    if isinstance(value, dict):
+        return {k: mask_value(v, k) for k, v in value.items()}
+    return value
+
+def mask_result(result: ProviderResult) -> dict[str, Any]:
+    data = result.model_dump(mode="json")
+    return {k: mask_value(v, k) for k, v in data.items()}
+
+def mask_results(results: list[ProviderResult]) -> list[dict[str, Any]]:
+    return [mask_result(result) for result in results]
+

--- a/eagleosint/output.py
+++ b/eagleosint/output.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 import csv
 import json
 import sys
-from typing import TextIO
+from typing import TextIO, Any
 
+from eagleosint.masking import mask_result, mask_results
 from eagleosint.models import ProviderResult
 
 def write_results(
         results: list[ProviderResult],
         fmt: str,
-        dest: TextIO = sys.stdout
+        dest: TextIO = sys.stdout,
+        show_pii: bool = False
 ) -> None:
     """
     Serialize results to dest in the requested format.
@@ -21,14 +23,17 @@ def write_results(
     if not results:
         return
 
+    rows: list[dict[str, Any]]
+    if show_pii:
+        rows = [r.model_dump(mode="json") for r in results]
+    else:
+        rows = mask_results(results)
+
     if fmt == "json":
-        payload = [r.model_dump(mode="json") for r in results]
-        json.dump(payload, dest, indent=2, default=str)
+        json.dump(rows, dest, indent=2, default=str)
         dest.write("\n")
 
     elif fmt == "csv":
-        rows = [r.model_dump(mode="csv") for r in results]
-        # union of all keys preserves columns across mixed result types
         fieldnames = list(dict.fromkeys(k for row in rows for k in row))
         writer = csv.DictWriter(
             dest, fieldnames=fieldnames,
@@ -36,6 +41,5 @@ def write_results(
         )
         writer.writeheader()
         writer.writerows(rows)
-
     else:
         raise ValueError(f"unsupported output format: {fmt!r}")

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,155 @@
+"""Tests for PII masking utilities."""
+import pytest
+
+from eagleosint.masking import (
+    mask_email,
+    mask_ip,
+    mask_phone,
+    mask_result,
+    mask_results,
+    mask_string,
+    mask_value,
+)
+from eagleosint.models import (
+    AccountHit,
+    AccountStatus,
+    EmailResult,
+    EmailStatus,
+    GitHubProfile,
+    IPResult,
+    PhoneResult,
+)
+
+
+class TestMaskEmail:
+    def test_standard_email(self):
+        assert mask_email("john.doe@gmail.com") == "joh***@gm***.com"
+
+    def test_short_local(self):
+        assert mask_email("ab@example.org") == "a***@ex***.org"
+
+    def test_long_local(self):
+        assert mask_email("administrator@company.net") == "adm***@co***.net"
+
+
+class TestMaskPhone:
+    def test_international(self):
+        result = mask_phone("+39 333 1234567")
+        assert result.startswith("393")
+        assert result.endswith("567")
+        assert "*" in result
+
+    def test_short_number(self):
+        assert mask_phone("1234") == "1234"
+
+    def test_plain_digits(self):
+        result = mask_phone("3331234567")
+        assert result == "333****567"
+
+
+class TestMaskIp:
+    def test_ipv4(self):
+        assert mask_ip("192.168.1.42") == "192.168.*.*"
+
+    def test_preserves_first_two_octets(self):
+        assert mask_ip("10.0.0.1") == "10.0.*.*"
+
+
+class TestMaskString:
+    def test_masks_email_in_text(self):
+        text = "Contact john.doe@gmail.com for info"
+        result = mask_string(text)
+        assert "john.doe@gmail.com" not in result
+        assert "joh***@gm***.com" in result
+
+    def test_masks_ip_in_text(self):
+        text = "Server at 192.168.1.42 is down"
+        result = mask_string(text)
+        assert "192.168.*.*" in result
+
+    def test_no_pii(self):
+        text = "No sensitive data here"
+        assert mask_string(text) == text
+
+
+class TestMaskValue:
+    def test_pii_field_masked(self):
+        assert "***" in mask_value("test@example.com", "email")
+
+    def test_non_pii_field_unchanged(self):
+        assert mask_value("test@example.com", "source") == "test@example.com"
+
+    def test_list_recursion(self):
+        result = mask_value(["test@a.com", "b@c.org"], "email")
+        assert all("***" in v for v in result)
+
+    def test_dict_recursion(self):
+        data = {"email": "x@y.com", "name": "John"}
+        result = mask_value(data)
+        assert "***" in result["email"]
+        assert result["name"] == "John"
+
+    def test_non_string_passthrough(self):
+        assert mask_value(42, "email") == 42
+        assert mask_value(None, "email") is None
+        assert mask_value(True, "phone") is True
+
+
+class TestMaskResult:
+    def test_email_result_masked(self):
+        r = EmailResult(
+            query="john", email="john@example.com", status=EmailStatus.VALID
+        )
+        masked = mask_result(r)
+        assert "***" in masked["email"]
+        assert masked["query"] == "john"
+        assert masked["status"] == "valid"
+
+    def test_phone_result_masked(self):
+        r = PhoneResult(
+            query="+391234567890", phone="+391234567890",
+            international_number="+39 123 456 7890",
+        )
+        masked = mask_result(r)
+        assert "***" not in masked["query"]
+        assert "*" in masked["phone"]
+        assert "*" in masked["international_number"]
+
+    def test_ip_result_masked(self):
+        r = IPResult(query="myip", ip="8.8.8.8", hostname="dns.google")
+        masked = mask_result(r)
+        assert masked["ip"] == "8.8.*.*"
+        assert "***" in masked["hostname"]
+
+    def test_account_hit_no_pii_fields(self):
+        r = AccountHit(
+            query="testuser", platform="github",
+            url="https://github.com/testuser",
+            status=AccountStatus.FOUND, http_status_code=200,
+        )
+        masked = mask_result(r)
+        assert masked["url"] == "https://github.com/testuser"
+        assert masked["platform"] == "github"
+
+    def test_github_email_masked(self):
+        r = GitHubProfile(
+            query="octocat", username="octocat",
+            email="octocat@github.com",
+        )
+        masked = mask_result(r)
+        assert "***" in masked["email"]
+        assert masked["username"] == "octocat"
+
+
+class TestMaskResults:
+    def test_multiple_results(self):
+        results = [
+            EmailResult(query="a", email="a@b.com", status=EmailStatus.VALID),
+            EmailResult(query="b", email="x@y.org", status=EmailStatus.INVALID),
+        ]
+        masked = mask_results(results)
+        assert len(masked) == 2
+        assert all("***" in m["email"] for m in masked)
+
+    def test_empty_list(self):
+        assert mask_results([]) == []


### PR DESCRIPTION
## Summary
- Add PII masking module that redacts email, phone, IP, and hostname in structured output
- Output is masked by default; use --show-pii flag to reveal raw data
- Applied to all CLI commands that support --output

## Files changed
- eagleosint/masking.py — new module with mask functions and regex patterns
- eagleosint/output.py — integrated masking into write_results()
- eagleosint/cli.py — added --show-pii flag to all output commands
- tests/test_masking.py — 23 tests

## Test plan
- [x] All 146 tests pass
- [x] JSON/CSV output masked by default
- [x] --show-pii reveals unmasked data
- [x] Email, phone, IP, hostname masking verified